### PR TITLE
update bundler to 2.2.22, bump mimemagic

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,7 +89,9 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.0425)
-    mimemagic (0.3.4)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.0)
@@ -171,4 +173,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.17.3
+   2.2.22


### PR DESCRIPTION
This PR updates Bundler to 2.2.22 and regenerates the Gemfile.lock to explicitly define the source of each gem.